### PR TITLE
Update help display for Las 2.0 options

### DIFF
--- a/src/las_args.cpp
+++ b/src/las_args.cpp
@@ -31,15 +31,16 @@ static const char *helptext =
 "Usage: lasUtil -f <las_filename> [-p <sections_to_print>]\n"
 " \n"
 "- Sections to print:\n"
+"  By default all sections are displayed\n"
 "  Specify which sections to display by listing the letters following '-p'\n"
 "  Example:\n"
 "  lasUtil -f myfile -p vw\n"
 "    Letter  : Section\n"
 "    v       : Version Information Section\n"
 "    w       : Well Information Section\n"
-"    p       : Log Parameter Section\n"
-"    d       : Log Definition Section\n"
-"    e       : Drilling Definition Section\n"
+"    c       : Curve Section\n"
+"    p       : Parameter Section\n"
+"    o       : Other Section\n"
 "    a       : Drilling Data Section\n";
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,14 @@ int main(int argc, char *argv[])
     }
 
     /* ----------------------------------------------------
-     * Get Log_Parameter Section
+     * Get Curve Section
+     * ----------------------------------------------------*/
+    if (is_section_printable('c')) {
+        std::cout << "Parsing 'Curve' Section isn't available yet\n";
+    }
+
+    /* ----------------------------------------------------
+     * Get Parameter : Log_Parameter Section
      * ----------------------------------------------------*/
     LasLogParam LLogParam;
 
@@ -138,6 +145,7 @@ int main(int argc, char *argv[])
     /* ----------------------------------------------------
      * Get Log_Definition Section
      * ----------------------------------------------------*/
+    /*
     LasLogParam LLogDef;
 
     trim(line);
@@ -160,6 +168,14 @@ int main(int argc, char *argv[])
         if (is_section_printable('d')) {
           LLogDef.printInfo();
         }
+    }
+    */
+
+    /* ----------------------------------------------------
+     * Get Other Section
+     * ----------------------------------------------------*/
+    if (is_section_printable('o')) {
+        std::cout << "Parsing 'Other' Section isn't available yet\n";
     }
 
     /* ----------------------------------------------------


### PR DESCRIPTION
#### Description:
Resolve #13 Update -h help display for las 2.0 section options:

#### Changes:
- 'c' for Curves section
- 'o' for Other section
- remove Las 3.0 specific options.